### PR TITLE
feat(server):add implements the fallback mechanism,Additionally, a CI pipeline has been added to ensure build stability.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: AnyTLS CI
+
+on:
+  push:
+    branches: [ "master", "main" ]
+  pull_request:
+    branches: [ "master", "main" ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.24.x' ]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Download dependencies
+      run: go mod download
+
+    - name: Run tests
+      run: go test -v ./...
+
+    - name: Build Server
+      run: go build -v ./cmd/server
+
+    - name: Build Client
+      run: go build -v ./cmd/client

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -21,6 +21,7 @@ func main() {
 	listen := flag.String("l", "0.0.0.0:8443", "server listen port")
 	password := flag.String("p", "", "password")
 	paddingScheme := flag.String("padding-scheme", "", "padding-scheme")
+	fallback := flag.String("fallback", "", "fallback address (host:port)")
 	flag.Parse()
 
 	if *password == "" {
@@ -68,7 +69,7 @@ func main() {
 	}
 
 	ctx := context.Background()
-	server := NewMyServer(tlsConfig)
+	server := NewMyServer(tlsConfig, *fallback)
 
 	for {
 		c, err := listener.Accept()

--- a/cmd/server/myserver.go
+++ b/cmd/server/myserver.go
@@ -5,12 +5,14 @@ import (
 )
 
 type myServer struct {
-	tlsConfig *tls.Config
+	tlsConfig    *tls.Config
+	fallbackAddr string
 }
 
-func NewMyServer(tlsConfig *tls.Config) *myServer {
+func NewMyServer(tlsConfig *tls.Config, fallbackAddr string) *myServer {
 	s := &myServer{
-		tlsConfig: tlsConfig,
+		tlsConfig:    tlsConfig,
+		fallbackAddr: fallbackAddr,
 	}
 	return s
 }


### PR DESCRIPTION
This is an implements of the fallback mechanism,that allows the AnyTLS server to mimic a standard Web server when authentication fails, effectively hiding the proxy service characteristics from active probes.

Technical Implementation
Initial Peeking
When a new TCP connection is established, the server first reads the first few hundred bytes into a memory buffer ( buf.Packet ). Specifically, it attempts to read the first 34 bytes (containing a 32-byte password hash + 2-byte padding length).

Verification
The server checks whether these 32 bytes match the SHA256 hash of the preset password:

Match : Identified as a legitimate AnyTLS client, proceeding with the proxy protocol flow.
No Match : Identified as illegitimate traffic (possibly an active probe script, browser misaccess, or crawler), triggering the fallback flow.
Buffer Rewind (Key Step)
Since the first 34 bytes have already been "read" by the program, directly forwarding the remaining traffic to a backend decoy server (e.g., Nginx) would result in incomplete data (e.g., GET / HTTP/1.1 might be truncated to TP/1.1 ). This would cause Nginx to error or close the connection, exposing the presence of a proxy.

AnyTLS leverages b.Resize(0, n) to reset the buffer's read pointer. This effectively "pushes back" the 34 bytes that were just read. The original connection is then wrapped using bufio.NewCachedConn to ensure that subsequent reads first retrieve this "pushed back" data before reading new data from the network.

Transparent Proxying
The server initiates a TCP connection to the configured -fallback address (e.g., 127.0.0.1:80 ). It then establishes a bidirectional data copy channel.

Final Result
The complete HTTP request sent by the probe (or browser) is delivered to Nginx intact. The probe receives a standard Nginx default page (e.g., "Welcome to nginx!"), making it completely impossible to distinguish between a proxy server and a regular website.

@anytls 